### PR TITLE
refactor(request-options-type): Adding $ReadOnlyArray type to json property

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -7,7 +7,7 @@ type RequestOptionsType = {
     url : string,
     method? : string,
     headers? : { [key : string] : string },
-    json? : Object,
+    json? : $ReadOnlyArray<mixed> | Object,
     data? : { [key : string] : string },
     body? : string,
     win? : SameDomainWindowType,


### PR DESCRIPTION
Since arrays are valid JSON, we want to support them in the request payload.