### PR TITLE
Fire onClick handler on space keypress

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 /* @flow */
 
 export const KEY_CODES = {
-    ENTER: 13
+    ENTER: 13,
+    SPACE: 32
 };

--- a/src/dom.js
+++ b/src/dom.js
@@ -232,7 +232,7 @@ export function onClick(element : HTMLElement, handler : (Event) => void) {
     element.addEventListener('click', handler);
     element.addEventListener('keypress', (event : Event) => {
         // $FlowFixMe
-        if (event.keyCode === KEY_CODES.ENTER) {
+        if (event.keyCode === KEY_CODES.ENTER || event.keyCode === KEY_CODES.SPACE) {
             return handler(event);
         }
     });
@@ -648,7 +648,7 @@ export function iframe(options : IframeElementOptionsType = {}, container : ?HTM
     });
 
     const isIE = window.navigator.userAgent.match(/MSIE|Edge/i);
-    
+
     if (!frame.hasAttribute('id')) {
         frame.setAttribute('id', uniqueID());
     }


### PR DESCRIPTION
This PR updates `onClick` to call the handler function when either the "Enter" or "Space" keys are pressed, as-per [WAI-ARIA accessibility guidelines](https://www.w3.org/TR/wai-aria-practices/#button).


