### PR TITLE
Update isBrowser() to handle React Native

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -237,7 +237,7 @@ export function htmlEncode(html : string = '') : string {
 }
 
 export function isBrowser() : boolean {
-    return (typeof window !== 'undefined');
+    return (typeof window !== 'undefined') && window.location !== undefined;
 }
 
 export function querySelectorAll(selector : string, doc : HTMLElement = window.document) : $ReadOnlyArray<HTMLElement> {


### PR DESCRIPTION
See krakenjs/beaver-logger#38

React Native polyfills `window` (https://github.com/facebook/react-native/blob/v0.63.3/Libraries/Core/setUpGlobals.js#L21-L23), but not `window.location`