### PR TITLE
closes #16 - Update version numbers for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-   - "lts/*"
+  - 'lts/*'
+before_install:
+  - rm -rf node_modules
 before_script:
   - npm run flow-typed
 script: npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - 'lts/*'
-before_install:
-  - rm -rf node_modules
+   - "lts/*"
 before_script:
   - npm run flow-typed
 script: npm run build

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "flow-bin": "^0.135.0",
     "grumbler-scripts": "^3.0.83",
-    "mocha": "^8.1.3"
+    "mocha": "^4"
   },
   "dependencies": {
     "cross-domain-safe-weakmap": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "flow-bin": "^0.135.0",
-    "grumbler-scripts": "^3",
+    "grumbler-scripts": "^3.0.83",
     "mocha": "^4"
   },
   "dependencies": {
     "cross-domain-safe-weakmap": "^1.0.20",
-    "cross-domain-utils": "^2.0.10",
-    "zalgo-promise": "^1.0.28"
+    "cross-domain-utils": "^2.0.34",
+    "zalgo-promise": "^1.0.46"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "flow-bin": "^0.135.0",
-    "grumbler-scripts": "^3.0.83",
+    "grumbler-scripts": "^3",
     "mocha": "^4"
   },
   "dependencies": {
-    "cross-domain-safe-weakmap": "^1.0.20",
-    "cross-domain-utils": "^2.0.34",
-    "zalgo-promise": "^1.0.46"
+    "cross-domain-safe-weakmap": "^1",
+    "cross-domain-utils": "^2",
+    "zalgo-promise": "^1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "flow-bin": "^0.135.0",
     "grumbler-scripts": "^3.0.83",
-    "mocha": "^4"
+    "mocha": "^8.1.3"
   },
   "dependencies": {
     "cross-domain-safe-weakmap": "^1.0.20",


### PR DESCRIPTION
closes #16 
	
I made this PR while experimenting with making the testing structure [less confusing](https://github.com/krakenjs/belter/issues/18) -- I thought that I needed to update the grumbler-scripts dependency because I was getting an error. I decided I might as well update the rest of the dependencies too.

Please advise if there is anything else in the package.json file I should update as well!

I did not update the devDependecy `flow-bin` because when I did that, I `npm run test` gave me errors relating to flow.
Here is an example `error` that occured when I ran `npm run test` with an updated `flow-bin` version
<img width="574" alt="Screen Shot 2020-10-15 at 3 32 09 PM" src="https://user-images.githubusercontent.com/45890848/96192835-bc14ec00-0efb-11eb-95d7-8d54b1a37f5f.png">

I did not update `mocha` because when updated to the latest version, the travis CI build failed -- errors made it such that tests could not run. The tests were able to work on my local machine though. 

After the travis CI build failed, I removed the update to `mocha` version number. However, the travis CI build still failed. 
I added to the `.travis.yml` file to remove all node modules before installing dependencies, and that solved the issue.