### PR TITLE
[2/12] tests functionality of waitForWindowReady.js in src/dom.js. Issue #10

### DIFF
--- a/test/tests/dom/index.js
+++ b/test/tests/dom/index.js
@@ -4,3 +4,4 @@ import './extendUrl';
 import './urlEncode';
 import './isDocumentReady';
 import './isDocumentInteractive';
+import './waitForWindowReady';

--- a/test/tests/dom/waitForWindowReady.js
+++ b/test/tests/dom/waitForWindowReady.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import { waitForWindowReady } from '../../../src/dom';
+
+describe('waitForWindowReady function', () => {
+    const oldState = document.readyState;
+
+    afterEach(() => {
+        document.readyState = oldState;
+    });
+
+    it('should resolve when window ready', async () => {
+        try {
+            document.readyState = 'complete';
+            await waitForWindowReady();
+        } catch (err) {
+            throw new Error('Expected waitForWindowReady to resolve');
+        }
+    });
+
+    it('should resolve when window eventually loads', async () => {
+        try {
+            document.readyState = 'loading';
+            setTimeout(() => {
+                document.readyState = 'complete';
+            }, 500);
+            await waitForWindowReady();
+        } catch (err) {
+            throw new Error('Expected waitForWindowReady to eventually resolve');
+        }
+    });
+});


### PR DESCRIPTION
waitForWindowReady:

* as the name suggests, it waits for the window to be ready
* it does this by checking if `document.readyState === complete`
* the tests do not cover rejection as they are not handled in the function (maybe they should be?)