### PR TITLE
[issue #33] Possible fix for issue 33

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -63,11 +63,7 @@ export function waitForDocumentBody() : ZalgoPromise<HTMLBodyElement> {
         }
 
         return waitForDocumentReady().then(() => {
-            if (document.body) {
-                return document.body;
-            }
-
-            throw new Error('Document ready but document.body not present');
+            return document.body;
         });
     });
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -56,7 +56,7 @@ export const waitForDocumentReady : WaitForDocumentReady = memoize(() => {
     });
 });
 
-export function waitForDocumentBody() : ZalgoPromise<HTMLBodyElement> {
+export function waitForDocumentBody() : ZalgoPromise<HTMLBodyElement | null> {
     return ZalgoPromise.try(() => {
         if (document.body) {
             return document.body;


### PR DESCRIPTION
* Removed the if conditional as it is unnecessary.
* Why?: `waitForDocumentReady` will only resolve if both `document.body` and `document.readyState` are `true`

* Removed the `throw` statement, as it is wasn't reachable
