### PR TITLE
update #38 - add a semicolon rule in eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     'extends': require.resolve('grumbler-scripts/config/.eslintrc-browser'),
 
     'rules': {
-        'default-param-last': 'off'
-    }
+        'default-param-last': 'off',
+        'semi': 0
+    }    
 };


### PR DESCRIPTION
updates #38 
This PR fixes a semicolon issue during npm run lint.

Example of error
![Screen Shot 2020-10-29 at 6 46 55 PM](https://user-images.githubusercontent.com/37395482/97651053-59057800-1a18-11eb-9dfa-2b54dbdb4362.png)

Should I change this in this repo or in https://github.com/krakenjs/grumbler-scripts/blob/master/config/.eslintrc-browser.js?
