### PR TITLE
updates #10 - Tests for src/device.js (5/5) 

### DIFF
--- a/test/tests/device/index.js
+++ b/test/tests/device/index.js
@@ -20,3 +20,6 @@ import './isIECompHeader';
 import './isElectron';
 import './isIEIntranet';
 import './isMacOsCna';
+import './supportsPopups';
+import './isChrome';
+import './isSafari';

--- a/test/tests/device/isChrome.js
+++ b/test/tests/device/isChrome.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isChrome  } from '../../../src/device';
+import { isChrome } from '../../../src/device';
 
 describe('isChrome', () => {
     it('should return true when userAgent contains Chrome', () => {

--- a/test/tests/device/isChrome.js
+++ b/test/tests/device/isChrome.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import { isChrome  } from '../../../src/device';
+
+describe('isChrome', () => {
+    it('should return true when userAgent contains Chrome', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'Chrome';
+        const bool = isChrome();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return true when userAgent contains Chromium', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'Chromium';
+        const bool = isChrome();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return true when userAgent contains CriOS', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'CriOS';
+        const bool = isChrome();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when userAgent is invalid', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'p0tatO';
+        const bool = isChrome();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+});

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import { isSafari  } from '../../../src/device';
+
+describe('isSafari', () => {
+    it('should return true when userAgent contains Safari and isChrome function returns false', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'Safari';
+        const bool = isSafari();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when userAgent contains Safari and isChrome function returns false', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'SafariChrome';
+        const bool = isSafari();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when userAgent does not contain Safari', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'potato';
+        const bool = isSafari();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+});

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -19,7 +19,7 @@ describe('isSafari', () => {
             throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
         }
     });
-    it('should return false when userAgent does not contain Safari', () => {
+    it('should return false when userAgent does NOT contain Safari', () => {
         // eslint-disable-next-line compat/compat
         window.navigator.userAgent = 'potato';
         const bool = isSafari();

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -11,7 +11,7 @@ describe('isSafari', () => {
             throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
         }
     });
-    it('should return false when userAgent contains Safari and isChrome function returns false', () => {
+    it('should return false when userAgent contains Safari and isChrome function returns true', () => {
         // eslint-disable-next-line compat/compat
         window.navigator.userAgent = 'SafariChrome';
         const bool = isSafari();

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isSafari  } from '../../../src/device';
+import { isSafari } from '../../../src/device';
 
 describe('isSafari', () => {
     it('should return true when userAgent contains Safari and isChrome function returns false', () => {

--- a/test/tests/device/supportsPopups.js
+++ b/test/tests/device/supportsPopups.js
@@ -1,0 +1,102 @@
+/* @flow */
+
+import { supportsPopups } from '../../../src/device';
+
+describe('supportsPopups', () => {
+    beforeEach(() => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'anthonykhoa wants to work at paypal :D';
+        Object.defineProperty(window, 'status', { writable: true, value: {} });
+    });
+    it('should return false when isIosWebview function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'iPhone GSA';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isAndroidWebview function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'AndroidVersion/9';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isOperaMini function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'Opera Mini';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isFirefoxIOS function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'fxios';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isEdgeIOS function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'edgios';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isFacebookWebView function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'FBAN';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when QQBrowser function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'QQBrowser';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isElectron function returns true', () => {
+        global.process.versions.electron = true;
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isMacOsCna function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.userAgent = 'macintosh.potatoAppleWebKit';
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when isStandAlone function returns true', () => {
+        // eslint-disable-next-line compat/compat
+        window.navigator.standalone = true;
+        const bool = supportsPopups();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return true when every function call returns false', () => {
+        // makes isElectron function return false
+        global.process = {};
+        // matchMedia and navigator.standalone are set to make isStandAlone function return false
+        window.matchMedia = () => ({ matches: false });
+        // eslint-disable-next-line compat/compat
+        window.navigator.standalone = false;
+        const bool = supportsPopups();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+});


### PR DESCRIPTION
updates #10 
This PR makes tests for 3 functions in `src/device.js`, and is part five of five PRs

1) isSafari
2) isChrome
3) supportsPopups

100% line coverage for device.js, woohoo!

<img width="444" alt="Screen Shot 2020-10-29 at 8 51 26 PM" src="https://user-images.githubusercontent.com/45890848/97658356-58c1a880-1a29-11eb-80b9-04a88b17a36e.png">
