### PR TITLE
Use strHashStr() for uid hash

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -6,7 +6,7 @@ import { linkFrameWindow, isWindowClosed, assertSameDomain,
 import { WeakMap } from 'cross-domain-safe-weakmap/src';
 
 import { inlineMemoize, memoize, noop, stringify, capitalizeFirstLetter,
-    once, extend, safeInterval, uniqueID, arrayFrom, ExtendableError, hashStr } from './util';
+    once, extend, safeInterval, uniqueID, arrayFrom, ExtendableError, strHashStr } from './util';
 import { isDevice } from './device';
 import { KEY_CODES, ATTRIBUTES } from './constants';
 import type { CancelableType } from './types';
@@ -226,7 +226,7 @@ export function getPageRenderTime() : ZalgoPromise<?number> {
         if (!performance) {
             return;
         }
-        
+
         const timing = performance.timing;
 
         if (timing.connectEnd && timing.domInteractive) {
@@ -1021,7 +1021,7 @@ export function onResize(el : HTMLElement, handler : ({| width : number, height 
     let timeout;
 
     win.addEventListener('resize', check);
-    
+
     if (typeof win.ResizeObserver !== 'undefined') {
         observer = new win.ResizeObserver(check);
         observer.observe(el);
@@ -1099,7 +1099,7 @@ export function getShadowHost(element : Node) : ?HTMLElement {
         return shadowRoot.host;
     }
 }
-  
+
 
 export function insertShadowSlot(element : HTMLElement) : HTMLElement {
     const shadowHost = getShadowHost(element);
@@ -1218,7 +1218,7 @@ export const getCurrentScriptUID : GetCurrentScriptUID = memoize(() => {
 
         const { src, dataset } = script;
         const stringToHash = JSON.stringify({ src, dataset });
-        const hashedString = hashStr(stringToHash);
+        const hashedString = strHashStr(stringToHash).slice(20);
 
         uid = `uid_${ hashedString }`;
     } else {

--- a/test/tests/dom/getCurrentScriptUID.js
+++ b/test/tests/dom/getCurrentScriptUID.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getCurrentScriptUID, getCurrentScript, memoize, ATTRIBUTES, hashStr } from '../../../src';
+import { getCurrentScriptUID, getCurrentScript, memoize, ATTRIBUTES, strHashStr } from '../../../src';
 
 
 beforeEach(() => {
@@ -14,7 +14,7 @@ beforeEach(() => {
 describe('get current script UID', () => {
 
     it('should create a data-uid-auto attribute', () => {
-        
+
         getCurrentScriptUID();
 
         const currentScript = getCurrentScript();
@@ -26,15 +26,15 @@ describe('get current script UID', () => {
             );
         }
     });
-  
+
     it('should use script\'s src and attributes to create the script UID', () => {
 
         const currentScript : HTMLScriptElement = getCurrentScript();
         const { src, dataset } = currentScript;
         const stringToHash = JSON.stringify({ src, dataset });
-        const hashedString = hashStr(stringToHash);
+        const hashedString = strHashStr(stringToHash).slice(20);
         const uidToCompare = `uid_${ hashedString }`;
-        
+
         const uidString : string = getCurrentScriptUID();
 
         if (uidString !== uidToCompare) {

--- a/test/tests/dom/getCurrentScriptUID.js
+++ b/test/tests/dom/getCurrentScriptUID.js
@@ -32,7 +32,8 @@ describe('get current script UID', () => {
         const currentScript : HTMLScriptElement = getCurrentScript();
         const { src, dataset } = currentScript;
         const stringToHash = JSON.stringify({ src, dataset });
-        const hashedString = strHashStr(stringToHash).slice(20);
+        const maxLengthForHashString = 20;
+        const hashedString = strHashStr(stringToHash).slice(maxLengthForHashString);
         const uidToCompare = `uid_${ hashedString }`;
 
         const uidString : string = getCurrentScriptUID();


### PR DESCRIPTION
This PR fixes an issue where the hash value in the uid overflows. Ex:
<img width="1144" alt="uid-hash-issue" src="https://user-images.githubusercontent.com/534034/118191808-cdc75f00-b40a-11eb-8b01-cd7ae4bd14ab.png">

strHashStr() will create a hex string instead and we limit it 20 characters.