### PR TITLE
Fix slice() usage with uid hash

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1218,7 +1218,7 @@ export const getCurrentScriptUID : GetCurrentScriptUID = memoize(() => {
 
         const { src, dataset } = script;
         const stringToHash = JSON.stringify({ src, dataset });
-        const hashedString = strHashStr(stringToHash).slice(20);
+        const hashedString = strHashStr(stringToHash).slice(0, 20);
 
         uid = `uid_${ hashedString }`;
     } else {

--- a/test/tests/dom/getCurrentScriptUID.js
+++ b/test/tests/dom/getCurrentScriptUID.js
@@ -33,7 +33,7 @@ describe('get current script UID', () => {
         const { src, dataset } = currentScript;
         const stringToHash = JSON.stringify({ src, dataset });
         const maxLengthForHashString = 20;
-        const hashedString = strHashStr(stringToHash).slice(maxLengthForHashString);
+        const hashedString = strHashStr(stringToHash).slice(0, maxLengthForHashString);
         const uidToCompare = `uid_${ hashedString }`;
 
         const uidString : string = getCurrentScriptUID();


### PR DESCRIPTION
I forgot that slice is `slice(beginIndex, endIndex)`. 

Nice catch @leogedler!