### PR TITLE
Modify UID hashing logic

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,5 @@ export const KEY_CODES = {
 export const ATTRIBUTES = {
     UID: 'data-uid'
 };
+
+export const UID_HASH_LENGTH = 30;

--- a/src/dom.js
+++ b/src/dom.js
@@ -8,7 +8,7 @@ import { WeakMap } from 'cross-domain-safe-weakmap/src';
 import { inlineMemoize, memoize, noop, stringify, capitalizeFirstLetter,
     once, extend, safeInterval, uniqueID, arrayFrom, ExtendableError, strHashStr } from './util';
 import { isDevice } from './device';
-import { KEY_CODES, ATTRIBUTES } from './constants';
+import { KEY_CODES, ATTRIBUTES, UID_HASH_LENGTH } from './constants';
 import type { CancelableType } from './types';
 
 type ElementRefType = string | HTMLElement;
@@ -1218,9 +1218,16 @@ export const getCurrentScriptUID : GetCurrentScriptUID = memoize(() => {
 
         const { src, dataset } = script;
         const stringToHash = JSON.stringify({ src, dataset });
-        const hashedString = strHashStr(stringToHash).slice(0, 20);
+        const hashedString = strHashStr(stringToHash);
 
-        uid = `uid_${ hashedString }`;
+        let hashResult : string;
+        if (hashedString.length > UID_HASH_LENGTH) {
+            hashResult = hashedString.slice(hashedString.length - UID_HASH_LENGTH);
+        } else {
+            hashResult = hashedString;
+        }
+
+        uid = `uid_${ hashResult }`;
     } else {
         uid = uniqueID();
     }

--- a/test/tests/dom/getCurrentScriptUID.js
+++ b/test/tests/dom/getCurrentScriptUID.js
@@ -32,15 +32,25 @@ describe('get current script UID', () => {
         const currentScript : HTMLScriptElement = getCurrentScript();
         const { src, dataset } = currentScript;
         const stringToHash = JSON.stringify({ src, dataset });
-        const maxLengthForHashString = 20;
-        const hashedString = strHashStr(stringToHash).slice(0, maxLengthForHashString);
-        const uidToCompare = `uid_${ hashedString }`;
+        const hashedString = strHashStr(stringToHash);
 
         const uidString : string = getCurrentScriptUID();
+        const uidStringWithoutPrefix = uidString.split('uid_')[1];
 
-        if (uidString !== uidToCompare) {
+        if (!hashedString.includes(uidStringWithoutPrefix)) {
             throw new Error(
-                `Should have a data-uid-auto attribute ${ uidToCompare }, got ${ uidString }`
+                `Should have generated a data-uid-auto hash value from ${ stringToHash }`
+            );
+        }
+
+        currentScript.removeAttribute(`${ ATTRIBUTES.UID }-auto`);
+        currentScript.setAttribute('data-custom-attribute', '123456');
+        memoize.clear();
+        const uidString2 : string = getCurrentScriptUID();
+
+        if (uidString === uidString2) {
+            throw new Error(
+                `Should have generated a new data-uid-auto hash value when the attributes change, got ${ uidString2 }`
             );
         }
     });


### PR DESCRIPTION
- Modified UID hashing logic to use the last 30 characters of the generated hash, this to consider all possible existing attributes added to the script.

- Added new test for the method `getCurrentScriptUID`, to check if all attributes are being considered.