### PR TITLE
License Badge Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,12 @@
     "url": "git://github.com/krakenjs/belter.git"
   },
   "keywords": [
-    "template"
+    "template",
+    "browser",
+    "utilities",
+    "tools"
   ],
-  "licenses": [
-    {
-      "type": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
     "flow-bin": "0.135.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "url": "git://github.com/krakenjs/belter.git"
   },
   "keywords": [
-    "template",
     "browser",
     "utilities",
     "tools"


### PR DESCRIPTION
Updating the package.json to use the current license [property](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license), which should fix the issue with the license badge in the readme.