### PR TITLE
Prevent popups for Epic Games Launcher app

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -62,6 +62,10 @@ export function isGoogleSearchApp(ua? : string = getUserAgent()) : boolean {
     return (/\bGSA\b/).test(ua);
 }
 
+export function isEpicGamesLauncher(ua? : string = getUserAgent()) : boolean {
+    return (/EpicGamesLauncher/i).test(ua);
+}
+
 export function isQQBrowser(ua? : string = getUserAgent()) : boolean {
     return (/QQBrowser/).test(ua);
 }
@@ -115,7 +119,7 @@ export function isSFVCorSafari(ua? : string = getUserAgent()) : boolean {
         if (scale > 1 &&
             possibleSafariSizes[scale] &&
             possibleSafariSizes[scale].indexOf(computedHeight) !== -1) {
-                
+
             maybeSafari = true;
         }
 
@@ -194,7 +198,7 @@ export function isMacOsCna() : boolean {
 
 export function supportsPopups(ua? : string = getUserAgent()) : boolean {
     return !(isIosWebview(ua) || isAndroidWebview(ua) || isOperaMini(ua) ||
-        isFirefoxIOS(ua) || isEdgeIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna() || isStandAlone());
+        isFirefoxIOS(ua) || isEdgeIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna() || isStandAlone() || isEpicGamesLauncher());
 }
 
 export function isChrome(ua? : string = getUserAgent()) : boolean {

--- a/test/tests/device/isEpicGamesLauncher.js
+++ b/test/tests/device/isEpicGamesLauncher.js
@@ -1,0 +1,26 @@
+/* @flow */
+
+import { isEpicGamesLauncher  } from '../../../src/device';
+
+describe('isEpicGamesLauncher', () => {
+    beforeEach(() => {
+
+        window.navigator = {};
+    });
+    it('should return true when userAgent contains EpicGamesLauncher(case insensitive)', () => {
+
+        window.navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) EpicGamesLauncher/13.0.7-18049148+++Portal+Release-Live UnrealEngine/4.23.0-18049148+++Portal+Release-Live Chrome/84.0.4147.38 Safari/537.36';
+        const bool = isEpicGamesLauncher();
+        if (!bool) {
+            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
+        }
+    });
+    it('should return false when userAgent does NOT contain EpicGamesLauncher(case insensitive)', () => {
+
+        window.navigator.userAgent = 'fired potato';
+        const bool = isEpicGamesLauncher();
+        if (bool) {
+            throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+        }
+    });
+});


### PR DESCRIPTION
Draft PR to add support for detecting the Epic Games Launcher app that uses an embedded browser. We want to detect this user agent string to prevent showing the popup since it's not supported.