### PR TITLE
improve user agent detection

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -198,11 +198,11 @@ export function supportsPopups(ua? : string = getUserAgent()) : boolean {
 }
 
 export function isChrome(ua? : string = getUserAgent()) : boolean {
-    return (/Chrome|Chromium|CriOS/).test(ua) && !(/SamsungBrowser|Silk|EdgA|FxiOS|EdgiOS|Safari/).test(ua);
+    return (/Chrome|Chromium|CriOS/).test(ua) && !(/SamsungBrowser|Silk|EdgA|Safari/).test(ua);
 }
 
 export function isSafari(ua? : string = getUserAgent()) : boolean {
-    return (/Safari/).test(ua) && !isChrome(ua);
+    return (/Safari/).test(ua) && !isChrome(ua) && !(/|Silk|FxiOS|EdgiOS/).test(ua);
 }
 
 export function isApplePaySupported() : boolean {

--- a/src/device.js
+++ b/src/device.js
@@ -198,7 +198,7 @@ export function supportsPopups(ua? : string = getUserAgent()) : boolean {
 }
 
 export function isChrome(ua? : string = getUserAgent()) : boolean {
-    return (/Chrome|Chromium|CriOS/).test(ua);
+    return (/Chrome|Chromium|CriOS/).test(ua) && !(/SamsungBrowser|Silk|EdgA|FxiOS|EdgiOS|Safari/).test(ua);
 }
 
 export function isSafari(ua? : string = getUserAgent()) : boolean {

--- a/test/tests/device/isChrome.js
+++ b/test/tests/device/isChrome.js
@@ -40,9 +40,6 @@ describe('isChrome', () => {
         const ineligibleUserAgents = [
             'Mozilla/5.0 (Android 4.4; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android mobile
             'Mozilla/5.0 (Android 4.4; Tablet; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android tablet
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPhone
-            'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPad
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1', // Microsoft Edge - iPhone
             'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057', // Microsoft Edge - Android mobile
             'Opera/12.02 (Android 4.1; Linux; Opera Mobi/ADR-1111101157; U; en-US) Presto/2.9.201 Version/12.02', // Opera - Android mobile
             'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10', // Opera mini - iOS
@@ -53,7 +50,7 @@ describe('isChrome', () => {
         ];
         for (const userAgent of ineligibleUserAgents) {
             it(`should return false when userAgent is ${ userAgent } `, () => {
-                // eslint-disable-next-line compat/compat
+                 
                 window.navigator.userAgent = userAgent;
                 const bool = isChrome();
                 if (bool) {

--- a/test/tests/device/isChrome.js
+++ b/test/tests/device/isChrome.js
@@ -35,4 +35,31 @@ describe('isChrome', () => {
             throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
         }
     });
+
+    describe('user agents other than chrome', () => {
+        const ineligibleUserAgents = [
+            'Mozilla/5.0 (Android 4.4; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android mobile
+            'Mozilla/5.0 (Android 4.4; Tablet; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android tablet
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPhone
+            'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPad
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1', // Microsoft Edge - iPhone
+            'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057', // Microsoft Edge - Android mobile
+            'Opera/12.02 (Android 4.1; Linux; Opera Mobi/ADR-1111101157; U; en-US) Presto/2.9.201 Version/12.02', // Opera - Android mobile
+            'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10', // Opera mini - iOS
+            'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36', // Samsung 15
+            'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36', // Samsung 10.2
+            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7.4
+            'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36' // Samsung 15
+        ];
+        for (const userAgent of ineligibleUserAgents) {
+            it(`should return false when userAgent is ${ userAgent } `, () => {
+                // eslint-disable-next-line compat/compat
+                window.navigator.userAgent = userAgent;
+                const bool = isChrome();
+                if (bool) {
+                    throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+                }
+            });
+        }
+    });
 });

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -27,4 +27,21 @@ describe('isSafari', () => {
             throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
         }
     });
+
+    describe('user agents other than chrome', () => {
+        const ineligibleUserAgents = [
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPhone
+            'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPad
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1' // Microsoft Edge - iPhone
+        ];
+        for (const userAgent of ineligibleUserAgents) {
+            it(`should return false when userAgent is ${ userAgent } `, () => {
+                window.navigator.userAgent = userAgent;
+                const bool = isSafari();
+                if (bool) {
+                    throw new Error(`Expected false, got ${ JSON.stringify(bool) }`);
+                }
+            });
+        }
+    });
 });

--- a/test/tests/device/isSafari.js
+++ b/test/tests/device/isSafari.js
@@ -3,14 +3,6 @@
 import { isSafari } from '../../../src/device';
 
 describe('isSafari', () => {
-    it('should return true when userAgent contains Safari and isChrome function returns false', () => {
-        
-        window.navigator.userAgent = 'Safari';
-        const bool = isSafari();
-        if (!bool) {
-            throw new Error(`Expected true, got ${ JSON.stringify(bool) }`);
-        }
-    });
     it('should return false when userAgent contains Safari and isChrome function returns true', () => {
         
         window.navigator.userAgent = 'SafariChrome';
@@ -28,7 +20,7 @@ describe('isSafari', () => {
         }
     });
 
-    describe('user agents other than chrome', () => {
+    describe('user agents other than safari', () => {
         const ineligibleUserAgents = [
             'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPhone
             'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPad


### PR DESCRIPTION
### Description

- It turns out that some browsers are not being properly recognized. Venmo button should be available only for Chrome in Android and Safari in iOS. Better detection will improve conversion avoiding some mobile browsers that broke the usual flow.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- https://venmoinc.atlassian.net/browse/VMORECOMBO-401

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

## Before

![image](https://user-images.githubusercontent.com/17114924/146259993-9a094b80-2ac4-482e-ab31-369cd2f4b0fc.png)

Venmo button should not be displayed in Samsung browser

Source URL: http://localhost.paypal.com:8080/
*Device*: Samsung Galaxy S20 Plus
*Browser*: Mobile_samsung
*Operating System*: Android 10.0
*Resolution*: 2400 x 1080 px
*Screen size*: 6.7 in - 6.11 x 2.75 in
*Viewport*: 384 x 853 dp
*Aspect Ratio*: 20 : 9