### PR TITLE
Remove pageYOffset on SFVC check

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -82,10 +82,6 @@ export function isIosWebview(ua? : string = getUserAgent()) : boolean {
 
 export function isSFVC(ua? : string = getUserAgent()) : boolean {
     if (isIos(ua)) {
-        if (window.pageYOffset !== 0) {
-            return true;
-        }
-
         const height = window.innerHeight;
         const scale = Math.round(window.screen.width / window.innerWidth * 100) / 100;
         const computedHeight = Math.round(height * scale);


### PR DESCRIPTION
This PR fixes a bug where we will incorrectly detect SFVC if we scroll on the normal Safari browser prior to loading the button.