### PR TITLE
Improve `isElement` & `serializeArgs`

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -5,7 +5,7 @@ import { linkFrameWindow, isWindowClosed, assertSameDomain,
     type SameDomainWindowType, type CrossDomainWindowType } from 'cross-domain-utils/src';
 import { WeakMap } from 'cross-domain-safe-weakmap/src';
 
-import { inlineMemoize, memoize, noop, stringify, capitalizeFirstLetter,
+import { isElement, inlineMemoize, memoize, noop, stringify, capitalizeFirstLetter,
     once, extend, safeInterval, uniqueID, arrayFrom, ExtendableError, strHashStr } from './util';
 import { isDevice } from './device';
 import { KEY_CODES, ATTRIBUTES, UID_HASH_LENGTH } from './constants';
@@ -360,19 +360,6 @@ export function getBrowserLocales() : $ReadOnlyArray<{| country? : string, lang 
 
 export function appendChild(container : HTMLElement, child : HTMLElement | Text) {
     container.appendChild(child);
-}
-
-export function isElement(element : mixed) : boolean {
-
-    if (element instanceof window.Element) {
-        return true;
-    }
-
-    if (element !== null && typeof element === 'object' && element.nodeType === 1 && typeof element.style === 'object' && typeof element.ownerDocument === 'object') {
-        return true;
-    }
-
-    return false;
 }
 
 export function getElementSafe(id : ElementRefType, doc : Document | HTMLElement = document) : ?HTMLElement {

--- a/src/util.js
+++ b/src/util.js
@@ -7,6 +7,22 @@ import { WeakMap } from 'cross-domain-safe-weakmap/src';
 
 import type { CancelableType } from './types';
 
+export function isElement(element : mixed) : boolean {
+    let passed = false;
+
+    try {
+        if (element instanceof window.Element) {
+            passed = true;
+        } else if (element !== null && typeof element === 'object' && element.nodeType === 1 && typeof element.style === 'object' && typeof element.ownerDocument === 'object') {
+            passed = true;
+        }
+    } catch (_) {
+        // we don't have an element
+    }
+
+    return passed;
+}
+
 export function getFunctionName <T : Function>(fn : T) : string {
     return fn.name || fn.__name__ || fn.displayName || 'anonymous';
 }
@@ -113,13 +129,9 @@ function serializeArgs<T>(args : $ReadOnlyArray<T>) : string {
                 return `memoize[${ getObjectID(val) }]`;
             }
 
-            // Detect DOM elements
             // By default JSON.stringify(domElement) returns '{}'. This ensures that stays true even for non-standard
             // elements (e.g. React-rendered dom elements) with custom properties
-            if (
-                (typeof window !== 'undefined' && val instanceof window.Element) ||
-                (val !== null && typeof val === 'object' && val.nodeType === 1 && typeof val.style === 'object' && typeof val.ownerDocument === 'object')
-            ) {
+            if (isElement(val)) {
                 return {};
             }
 


### PR DESCRIPTION
### Move `isElement` from dom.js -> util.js
We need to use `isElement` in `serialzeArgs` but this creates a cyclical dependency (dom.js <-> util.js). We looked into different options to resolve this but moving `isElement` to `util.js` was the least complex.

### Improve `isElement` element checking
We ran into issues in `clientsdknodeweb` that threw errors for the current `isElement` check. We are mocking the window not but fully which throws a javascript exception for the `val instanceof window.Element` check. This was recommended from [stack overflow](https://stackoverflow.com/a/384380)

### Improve `serializeArgs` element checking
Finally, we used the improvements from `isElement` in `serialzeArgs` where this issue was actually found.