### PR TITLE
use new kraken org prefix for cross-domain-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "mocha": "^4"
   },
   "dependencies": {
+    "@krakenjs/cross-domain-utils": "^3.0.2",
     "cross-domain-safe-weakmap": "^1",
-    "cross-domain-utils": "^2",
     "zalgo-promise": "^1"
   }
 }

--- a/src/dom.js
+++ b/src/dom.js
@@ -2,7 +2,7 @@
 /* eslint max-lines: off */
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { linkFrameWindow, isWindowClosed, assertSameDomain,
-    type SameDomainWindowType, type CrossDomainWindowType } from 'cross-domain-utils/src';
+    type SameDomainWindowType, type CrossDomainWindowType } from '@krakenjs/cross-domain-utils/src';
 import { WeakMap } from 'cross-domain-safe-weakmap/src';
 
 import { isElement, inlineMemoize, memoize, noop, stringify, capitalizeFirstLetter,

--- a/src/http.js
+++ b/src/http.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { type SameDomainWindowType } from 'cross-domain-utils/src';
+import { type SameDomainWindowType } from '@krakenjs/cross-domain-utils/src';
 
 type RequestOptionsType = {|
     url : string,


### PR DESCRIPTION
`cross-domain-utils` -> `@krakenjs/cross-domain-utils`

no code changes