### PR TITLE
Add new iPhone Models to screenHeights.js

### DIFF
--- a/src/screenHeights.js
+++ b/src/screenHeights.js
@@ -66,7 +66,7 @@ export const sfvcScreens = {
   },
   "852": {
     device: "iPhone 14 Pro",
-    textSizeHeights: [666, 662, 658, 652],
+    textSizeHeights: [666, 662, 658], // 652 removed as same in Safari
     textSizeHeightsNoTabs: [774, 772, 770, 768],
     zoomHeight: {
       "1.15": [666, 662, 658], // 652 removed as same in Safari
@@ -79,6 +79,7 @@ export const sfvcScreens = {
       "3": [666, 663], // 657, 651 removed as same in Safari
     },
     maybeSafari: {
+      "1": [652],
       "1.15": [652],
       "1.25": [651],
       "1.5": [653],

--- a/src/screenHeights.js
+++ b/src/screenHeights.js
@@ -2,7 +2,7 @@
 
 export const sfvcScreens = {
   "926": {
-    device: "iPhone 12/13 Pro Max",
+    device: "iPhone 12/13 Pro Max, iPhone 14 Plus",
     textSizeHeights: [752, 748, 744, 738],
     textSizeHeightsNoTabs: [860, 858, 856, 854],
     zoomHeight: {
@@ -38,8 +38,31 @@ export const sfvcScreens = {
       "3": [714],
     },
   },
+  "852": {
+    device: "iPhone 14 Pro",
+    textSizeHeights: [666, 662, 658, 652],
+    textSizeHeightsNoTabs: [774, 772, 770, 768],
+    zoomHeight: {
+      "1.15": [666, 662, 658], // 652 removed as same in Safari
+      "1.25": [665, 661, 658], // 651 removed as same in Safari
+      "1.5": [666, 662, 659], // 653 removed as same in Safari
+      "1.75": [667, 662], // 658, 653 removed as same in Safari
+      "2": [663, 659], // 655, 649 removed as same in Safari
+      "2.5": [665, 663], // 658, 653 removed as same in Safari
+      "3": [666, 663], // 657, 651 removed as same in Safari
+    },
+    maybeSafari: {
+      "1.15": [652],
+      "1.25": [651],
+      "1.5": [653],
+      "1.75": [658, 653],
+      "2": [655, 649],
+      "2.5": [658, 653],
+      "3": [657, 651],
+    },
+  },
   "844": {
-    device: "iPhone 12, iPhone 12 Pro",
+    device: "iPhone 12, iPhone 12 Pro, iPhone 13",
     textSizeHeights: [670, 666, 662, 656],
     textSizeHeightsNoTabs: [778, 776, 774, 772],
     zoomHeight: {

--- a/src/screenHeights.js
+++ b/src/screenHeights.js
@@ -113,20 +113,28 @@ export const sfvcScreens = {
   },
   "812": {
     device: "iPhone X, iPhone XS, iPhone 11 Pro, iPhone 12 Mini",
-    textSizeHeights: [641, 637, 633, 627],
-    textSizeHeightsNoTabs: [749, 747, 745, 743],
+    textSizeHeights: [641, 637, 635, 633, 631, 627], // 621 removed as same in Safari
+    textSizeHeightsNoTabs: [749, 747, 745, 743, 741, 739, 737],
     zoomHeight: {
-      "1.15": [641, 637, 633, 627],
-      "1.25": [641, 638, 633, 628],
-      "1.5": [641, 638, 633, 627],
-      "1.75": [641, 637, 634], // 627 removed as same in Safari
-      "2": [642, 638, 634, 628],
-      "2.5": [640, 638, 633, 628],
-      "3": [642, 633], // 636, 627 removed as same in Safari
+      "1.15": [641, 637, 635, 633, 631], // 627, 621 removed as same in Safari
+      "1.25": [641, 638, 635, 633, 631, 628], // 621 removed as same in Safari
+      "1.5": [641, 638, 635, 633, 632, 621], // 627 removed as same in Safari
+      "1.75": [641, 637, 635, 634, 632], // 627, 621 removed as same in Safari
+      "1.99": [642, 638, 634, 633, 629, 628, 625], // 619 removed as same in Safari
+      "2": [642, 638, 634, 633, 629, 628, 625], // 619 removed as same in Safari
+      "2.5": [640, 638, 635, 633], // 630, 628, 620 removed as same in Safari
+      "3": [642, 633], // 636, 630, 627, 621 removed as same in Safari
     },
     maybeSafari: {
-      "1.75": [627],
-      "3": [636, 627],
+      "1": [621],
+      "1.15": [627, 621],
+      "1.25": [621],
+      "1.5": [627],
+      "1.75": [627, 621],
+      "1.99": [619],
+      "2": [619],
+      "2.5": [630, 628, 620],
+      "3": [636, 630, 627, 621],
     },
   },
   "736": {

--- a/src/screenHeights.js
+++ b/src/screenHeights.js
@@ -1,6 +1,32 @@
 /* @flow */
 
 export const sfvcScreens = {
+  "932": {
+    device: "iPhone 14 Pro Max",
+    textSizeHeights: [746, 742, 738], // 732 removed as same in Safari
+    textSizeHeightsNoTabs: [854, 852, 850, 848],
+    zoomHeight: {
+      "1.15": [746, 742, 738], // 733 removed as same in Safari
+      "1.25": [746, 743], // 738, 733 removed as same in Safari
+      "1.5": [746, 743], // 738, 732 removed as same in Safari
+      "1.75": [746, 742, 739], // 732 removed as same in Safari
+      "2": [746, 742], // 738, 732 removed as same in Safari
+      "2.5": [745, 743], // 738, 733 removed as same in Safari
+      "3": [749], // 743, 740, 734 removed as same in Safari
+      "3.01": [749], // 743, 740, 734 removed as same in Safari
+    },
+    maybeSafari: {
+      "1": [732],
+      "1.15": [733],
+      "1.25": [738, 733],
+      "1.5": [738, 732],
+      "1.75": [732],
+      "2": [738, 732],
+      "2.5": [738, 733],
+      "3": [743, 740, 734],
+      "3.01": [743, 740, 734],
+    },
+  },
   "926": {
     device: "iPhone 12/13 Pro Max, iPhone 14 Plus",
     textSizeHeights: [752, 748, 744, 738],
@@ -47,6 +73,7 @@ export const sfvcScreens = {
       "1.25": [665, 661, 658], // 651 removed as same in Safari
       "1.5": [666, 662, 659], // 653 removed as same in Safari
       "1.75": [667, 662], // 658, 653 removed as same in Safari
+      "1.99": [663, 659], // 655, 649 removed as same in Safari
       "2": [663, 659], // 655, 649 removed as same in Safari
       "2.5": [665, 663], // 658, 653 removed as same in Safari
       "3": [666, 663], // 657, 651 removed as same in Safari
@@ -56,6 +83,7 @@ export const sfvcScreens = {
       "1.25": [651],
       "1.5": [653],
       "1.75": [658, 653],
+      "1.99": [655, 649],
       "2": [655, 649],
       "2.5": [658, 653],
       "3": [657, 651],

--- a/src/screenHeights.js
+++ b/src/screenHeights.js
@@ -113,28 +113,20 @@ export const sfvcScreens = {
   },
   "812": {
     device: "iPhone X, iPhone XS, iPhone 11 Pro, iPhone 12 Mini",
-    textSizeHeights: [641, 637, 635, 633, 631, 627], // 621 removed as same in Safari
-    textSizeHeightsNoTabs: [749, 747, 745, 743, 741, 739, 737],
+    textSizeHeights: [641, 637, 633, 627],
+    textSizeHeightsNoTabs: [749, 747, 745, 743],
     zoomHeight: {
-      "1.15": [641, 637, 635, 633, 631], // 627, 621 removed as same in Safari
-      "1.25": [641, 638, 635, 633, 631, 628], // 621 removed as same in Safari
-      "1.5": [641, 638, 635, 633, 632, 621], // 627 removed as same in Safari
-      "1.75": [641, 637, 635, 634, 632], // 627, 621 removed as same in Safari
-      "1.99": [642, 638, 634, 633, 629, 628, 625], // 619 removed as same in Safari
-      "2": [642, 638, 634, 633, 629, 628, 625], // 619 removed as same in Safari
-      "2.5": [640, 638, 635, 633], // 630, 628, 620 removed as same in Safari
-      "3": [642, 633], // 636, 630, 627, 621 removed as same in Safari
+      "1.15": [641, 637, 633, 627],
+      "1.25": [641, 638, 633, 628],
+      "1.5": [641, 638, 633, 627],
+      "1.75": [641, 637, 634], // 627 removed as same in Safari
+      "2": [642, 638, 634, 628],
+      "2.5": [640, 638, 633, 628],
+      "3": [642, 633], // 636, 627 removed as same in Safari
     },
     maybeSafari: {
-      "1": [621],
-      "1.15": [627, 621],
-      "1.25": [621],
-      "1.5": [627],
-      "1.75": [627, 621],
-      "1.99": [619],
-      "2": [619],
-      "2.5": [630, 628, 620],
-      "3": [636, 630, 627, 621],
+      "1.75": [627],
+      "3": [636, 627],
     },
   },
   "736": {


### PR DESCRIPTION
### Summary
- Needed to add iPhone 14 Pro to `screenHeights.js` since the Venmo button was not showing up on that device.
- Also added a couple models that I found were missing just for consistency 😄 

### Conversation
- I'd love to document how we find this data.  I'm thinking of including that information in another PR, since we would have to find a way to organize our docs in this repo.  