### PR TITLE
perf: make 'touchstart' event listener passive

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -300,8 +300,15 @@ export function querySelectorAll(
   return Array.prototype.slice.call(doc.querySelectorAll(selector));
 }
 
+/**
+ * Sets up event handlers for click events and
+ * enter/space keypresses.
+ * @callback handler
+ * @param {HTMLElement} element
+ * @param {handler} handler
+ */
 export function onClick(element: HTMLElement, handler: (Event) => void) {
-  element.addEventListener("touchstart", noop);
+  element.addEventListener("touchstart", noop, { passive: true });
   element.addEventListener("click", handler);
   element.addEventListener("keypress", (event: Event) => {
     if (

--- a/test/tests/dom/index.js
+++ b/test/tests/dom/index.js
@@ -12,3 +12,4 @@ import "./getCurrentScriptUID";
 import "./submitForm";
 import "./getBody";
 import "./popup";
+import "./onClick";

--- a/test/tests/dom/onClick.js
+++ b/test/tests/dom/onClick.js
@@ -1,0 +1,17 @@
+/* @flow */
+
+import { onClick } from "../../../src";
+
+describe("onClick", () => {
+  it("invokes the handler given for click-like events", async () => {
+    const button = document.createElement("button");
+    let handlerCalled = false;
+    onClick(button, () => {
+      handlerCalled = true;
+    });
+    await button.dispatchEvent(new Event("click"));
+    if (!handlerCalled) {
+      throw new Error(`Expected handler to be called`);
+    }
+  });
+});


### PR DESCRIPTION
**JIRA**: https://engineering.paypalcorp.com/jira/browse/PPPLMER-110516

This PR removes the console warning from Chrome:
<img width="895" alt="Screen Shot 2022-10-25 at 13 50 19" src="https://user-images.githubusercontent.com/3824954/197857257-16c27d61-8e4e-4322-9f0c-708f6a2dec63.png">

More info about behavior here: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive

