### PR TITLE
[DTPPCPSDK-1334] feat: add isWebView check to supportsPopups

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -24,14 +24,13 @@ export function isTablet(userAgent?: string = getUserAgent()): boolean {
   return TABLET_PATTERN.test(userAgent);
 }
 
-export function isWebView(): boolean {
-  const userAgent = getUserAgent();
+export function isWebView(ua?: string = getUserAgent()): boolean {
   return (
     /(iPhone|iPod|iPad|Macintosh).*AppleWebKit(?!.*Safari)|.*WKWebView/i.test(
-      userAgent
+      ua
     ) ||
-    /\bwv\b/.test(userAgent) ||
-    /Android.*Version\/(\d)\.(\d)/i.test(userAgent)
+    /\bwv\b/.test(ua) ||
+    /Android.*Version\/(\d)\.(\d)/i.test(ua)
   );
 }
 
@@ -229,6 +228,7 @@ export function isMacOsCna(): boolean {
 
 export function supportsPopups(ua?: string = getUserAgent()): boolean {
   return !(
+    isWebView(ua) ||
     isIosWebview(ua) ||
     isAndroidWebview(ua) ||
     isOperaMini(ua) ||

--- a/test/tests/device/isWebView.js
+++ b/test/tests/device/isWebView.js
@@ -58,7 +58,7 @@ describe("isWebView", () => {
       throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
     }
   });
-  it("should return false when userAgent is valid and contains 'wv' in the words only", () => {
+  it("should return false when userAgent is valid and contains 'wv' in the word 'Dalwvik' only", () => {
     window.navigator.userAgent = `dkdfsna/5.25.638 Dalwvik/2.1.0 (Linux; U; Android 13; SM-S908U1 Build/TP1A.220624.014;)`;
     const bool = isWebView();
     if (bool) {

--- a/test/tests/device/isWebView.js
+++ b/test/tests/device/isWebView.js
@@ -50,4 +50,28 @@ describe("isWebView", () => {
       throw new Error(`Expected false, got ${JSON.stringify(bool)}`);
     }
   });
+  it("should return true when userAgent is valid and contains the wv field", () => {
+    window.navigator.userAgent =
+      "dkdfsna/5.25.638 Dalvik/2.1.0 (Linux; U; Android 13; SM-S908U1 Build/TP1A.220624.014; wv )";
+    const bool = isWebView();
+    if (!bool) {
+      throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+    }
+  });
+  it("should return false when userAgent is valid and contains 'wv' in the words only", () => {
+    window.navigator.userAgent = `dkdfsna/5.25.638 Dalwvik/2.1.0 (Linux; U; Android 13; SM-S908U1 Build/TP1A.220624.014;)`;
+    const bool = isWebView();
+    if (bool) {
+      throw new Error(`Expected false, got ${JSON.stringify(bool)}`);
+    }
+  });
+  it("should return true when it is a valid WebView UA in Android 10 and above", () => {
+    window.navigator.userAgent = `Mozilla/5.0 (Linux; U; Android 10; SM-G960F Build/QP1A.190711.020; wv)
+    AppleWebKit/537.36 (KHTML, like Gecko) 
+    Version/4.0 Chrome/95.0.4638.50 Mobile Safari/537.36 OPR/60.0.2254.59405`;
+    const bool = isWebView();
+    if (!bool) {
+      throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+    }
+  });
 });

--- a/test/tests/device/supportsPopups.js
+++ b/test/tests/device/supportsPopups.js
@@ -89,4 +89,69 @@ describe("supportsPopups", () => {
       throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
     }
   });
+  describe("Chrome for Android", () => {
+    it("should return true when it is a valid Phone UA", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) 
+      AppleWebKit/535.19 (KHTML, like Gecko) 
+      Chrome/18.0.1025.133 Mobile Safari/535.19`;
+      const bool = supportsPopups();
+      if (!bool) {
+        throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+      }
+    });
+    it("should return true when it is a valid Tablet UA", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) 
+      AppleWebKit/535.19 (KHTML, like Gecko) 
+      Chrome/18.0.1025.133 Safari/535.19`;
+      const bool = supportsPopups();
+      if (!bool) {
+        throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+      }
+    });
+  });
+  describe("Chrome for iOS", () => {
+    it("should return true when it is a valid Chrome UA on iPhone", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1`;
+      const bool = supportsPopups();
+      if (!bool) {
+        throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+      }
+    });
+    it("should return true when it is a valid Mobile Safari UA", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1`;
+      const bool = supportsPopups();
+      if (!bool) {
+        throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+      }
+    });
+    it("should return true when it is a valid Desktop Safari UA", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5)
+      AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85
+      Version/11.1.1 Safari/605.1.15`;
+      const bool = supportsPopups();
+      if (!bool) {
+        throw new Error(`Expected true, got ${JSON.stringify(bool)}`);
+      }
+    });
+  });
+  describe("WebView on Android", () => {
+    it("should return false when it is a valid WebView UA in KitKat to Lollipop", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (Linux; Android 4.4; Nexus 5 Build/_BuildID_) 
+      AppleWebKit/537.36 (KHTML, like Gecko) 
+      Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36`;
+      const bool = supportsPopups();
+      if (bool) {
+        throw new Error(`Expected false, got ${JSON.stringify(bool)}`);
+      }
+    });
+    it("should return false when it is a valid WebView UA in Lollipop to Android 10", () => {
+      window.navigator.userAgent = `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv)
+      AppleWebKit/537.36 (KHTML, like Gecko) 
+      Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`;
+      const bool = supportsPopups();
+      if (bool) {
+        throw new Error(`Expected false, got ${JSON.stringify(bool)}`);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Added isWebView() check to supportsPopups(), so new user agents for WebView which contains 'wv' will not support pop-ups. 
Added all [UA Strings](https://developer.chrome.com/docs/multidevice/user-agent/#webview-on-android)  to the test file.

UA does NOT support popup: `dkdfsna/5.25.638 Dalvik/2.1.0 (Linux; U; Android 13; SM-S908U1 Build/TP1A.220624.014; wv )`
<img width="1677" alt="Screenshot 2023-10-24 at 8 59 25 PM" src="https://github.com/krakenjs/belter/assets/31012905/c125f58f-5dd5-4c2d-be38-19d9d63a7ea8">

UA supports popup : ```Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) 
AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75
Mobile/14E5239e Safari/602.1```
<img width="1695" alt="Screenshot 2023-10-24 at 9 01 00 PM" src="https://github.com/krakenjs/belter/assets/31012905/027e76ba-9727-4885-8c85-d4b7484cf028">
