### PR TITLE
feat: update the meta webview detection logic to remove version check in regex

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -54,7 +54,7 @@ export function isMetaWebView(ua?: string = getUserAgent()): boolean {
 }
 
 export function isMetaInAppBrowser(ua?: string = getUserAgent()): boolean {
-  return /IABMV\/1/.test(ua);
+  return /IABMV/.test(ua);
 }
 
 export function isFirefox(ua?: string = getUserAgent()): boolean {


### PR DESCRIPTION
* As per latest update we can rely on `IABMV` in user agent to determine multi window supported webviews 