### PR TITLE
feat: add optional isBfcacheEnabled flag to watchElementForClose

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1041,8 +1041,10 @@ export function isElementClosed(el: HTMLElement): boolean {
 
 export function watchElementForClose(
   element: HTMLElement,
-  handler: () => mixed
+  handler: () => mixed,
+  options?: {| isBfcacheEnabled?: boolean |}
 ): CancelableType {
+  const { isBfcacheEnabled = false } = options || {};
   handler = once(handler);
   const terminationEvent = "onpagehide" in window ? "pagehide" : "unload";
 
@@ -1063,8 +1065,12 @@ export function watchElementForClose(
       interval.cancel();
     }
     if (sacrificialFrameWin) {
-      // eslint-disable-next-line no-use-before-define
-      sacrificialFrameWin.removeEventListener(terminationEvent, elementClosed);
+      /* eslint-disable no-use-before-define */
+      sacrificialFrameWin.removeEventListener(
+        terminationEvent,
+        elementClosedOnTermination
+      );
+      /* eslint-enable no-use-before-define */
     }
     if (sacrificialFrame) {
       destroyElement(sacrificialFrame);
@@ -1076,6 +1082,17 @@ export function watchElementForClose(
       handler();
       cancel();
     }
+  };
+
+  const elementClosedOnTermination = (event) => {
+    if (
+      isBfcacheEnabled &&
+      terminationEvent === "pagehide" &&
+      event.persisted
+    ) {
+      return;
+    }
+    elementClosed();
   };
 
   if (isElementClosed(element)) {
@@ -1107,7 +1124,10 @@ export function watchElementForClose(
   sacrificialFrame.style.display = "none";
   awaitFrameWindow(sacrificialFrame).then((frameWin) => {
     sacrificialFrameWin = assertSameDomain(frameWin);
-    sacrificialFrameWin.addEventListener(terminationEvent, elementClosed);
+    sacrificialFrameWin.addEventListener(
+      terminationEvent,
+      elementClosedOnTermination
+    );
   });
   element.appendChild(sacrificialFrame);
 


### PR DESCRIPTION
## What is the purpose of this PR?

Adds an optional third parameter to `watchElementForClose` with an `isBfcacheEnabled` flag (default `false`). When enabled, the sacrificial iframe's `pagehide` handler skips calling `elementClosed()` when `event.persisted` is `true`, preventing a false-positive close detection when a page enters the browser's back-forward cache (bfcache). Default behavior is unchanged for all existing callers, so this is non-breaking.

This is consumed by zoid's `parent.js`, which will pass `{ isBfcacheEnabled: bfcacheEnabled }` from its component option.

**Jira Ticket:** [DTPPCPSDK-5712](https://paypal.atlassian.net/browse/DTPPCPSDK-5712)

## Type of change

- [x] New feature (backward compatible change that adds new capability).
- [ ] UI change
- [ ] Bug fix.
- [ ] Breaking change (backward incompatible change). Provide references to customer impact and communication.
- [ ] Refactor (no functional change)

## Testing Plan

### Step-by-Step Validation

- Navigate to a page that calls `watchElementForClose(element, handler)` with no third argument. Confirm behavior is unchanged: `pagehide`/`unload` on the sacrificial iframe still calls `elementClosed()` immediately, including when `event.persisted` is `true`.
- Call `watchElementForClose(element, handler, { isBfcacheEnabled: true })`. Navigate away and use the back button to trigger bfcache restore. Confirm `elementClosed()` is NOT called while the page is in bfcache (sacrificial iframe's `pagehide` fires with `event.persisted === true` and is skipped).
- With `isBfcacheEnabled: true`, perform a real navigation away (not bfcache-eligible). Confirm `elementClosed()` IS called as before.
- Confirm MutationObserver and polling strategies for detecting element removal are unaffected (they still call `elementClosed()` directly).
- Confirm legacy browsers using the `unload` event (no `persisted` property) still call `elementClosed()` normally regardless of the flag.

### Rollback Considerations

Are there any services dependent on this change?

- [ ] Yes
- [x] No