### PR TITLE
fix: add access check for localstorage

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -33,6 +33,9 @@ export function getStorage({
       const newStateID = uniqueID();
 
       let accessedStorage;
+      // set when a localStorage write fails so the next read prefers the
+      // getGlobal() fallback instead of the (now stale) localStorage value
+      let fallbackHasNewerData = false;
 
       function getState<T>(handler: (storage: Object) => T): T {
         let localStorageEnabled;
@@ -47,6 +50,10 @@ export function getStorage({
 
         if (accessedStorage) {
           storage = accessedStorage;
+        }
+
+        if (!storage && fallbackHasNewerData) {
+          storage = getGlobal()[STORAGE_KEY];
         }
 
         if (!storage && localStorageEnabled) {
@@ -86,8 +93,9 @@ export function getStorage({
           try {
             window.localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
             wroteToLocalStorage = true;
+            fallbackHasNewerData = false;
           } catch (err) {
-            // pass
+            fallbackHasNewerData = true;
           }
         }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -35,7 +35,14 @@ export function getStorage({
       let accessedStorage;
 
       function getState<T>(handler: (storage: Object) => T): T {
-        const localStorageEnabled = isLocalStorageEnabled();
+        let localStorageEnabled;
+
+        try {
+          localStorageEnabled = window?.localStorage && isLocalStorageEnabled();
+        } catch (err) {
+          localStorageEnabled = false;
+        }
+
         let storage;
 
         if (accessedStorage) {
@@ -43,10 +50,15 @@ export function getStorage({
         }
 
         if (!storage && localStorageEnabled) {
-          const rawStorage = window.localStorage.getItem(STORAGE_KEY);
+          try {
+            const rawStorage = window.localStorage.getItem(STORAGE_KEY);
 
-          if (rawStorage) {
-            storage = JSON.parse(rawStorage);
+            if (rawStorage) {
+              storage = JSON.parse(rawStorage);
+            }
+          } catch (err) {
+            // localStorage access can fail mid-session (eg WKWebView storage
+            // errors), even after the initial feature-detection succeeded
           }
         }
 
@@ -68,9 +80,18 @@ export function getStorage({
 
         const result = handler(storage);
 
+        let wroteToLocalStorage = false;
+
         if (localStorageEnabled) {
-          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
-        } else {
+          try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
+            wroteToLocalStorage = true;
+          } catch (err) {
+            // pass
+          }
+        }
+
+        if (!wroteToLocalStorage) {
           getGlobal()[STORAGE_KEY] = storage;
         }
 

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -98,6 +98,7 @@ describe("storage", () => {
           getItem: () => {
             throw new Error("SecurityError: localStorage access denied");
           },
+          // eslint-disable-next-line no-empty-function
           setItem: () => {},
         },
         configurable: true,

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -1,8 +1,9 @@
 /* @flow */
-import { vi, describe, test, expect, beforeEach } from "vitest";
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
 
 import { getStorage } from "./storage";
-import { uniqueID } from "./util";
+import { uniqueID, getGlobal } from "./util";
+import { isLocalStorageEnabled } from "./dom";
 
 vi.mock("./util", async () => {
   const actual = await vi.importActual("./util");
@@ -12,6 +13,15 @@ vi.mock("./util", async () => {
     uniqueID: vi.fn(() => "unique-id-123"),
     getGlobal: vi.fn(() => ({})),
     inlineMemoize: vi.fn((_, impl) => impl()),
+  };
+});
+
+vi.mock("./dom", async () => {
+  const actual = await vi.importActual("./dom");
+
+  return {
+    ...actual,
+    isLocalStorageEnabled: vi.fn(() => true),
   };
 });
 
@@ -45,5 +55,98 @@ describe("storage", () => {
     });
 
     expect(getSessionID()).toEqual("sticky-session-id");
+  });
+
+  describe("when localStorage is unavailable mid-session", () => {
+    const originalLocalStorage = window.localStorage;
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      Object.defineProperty(window, "localStorage", {
+        value: originalLocalStorage,
+        configurable: true,
+      });
+    });
+
+    test("falls back to global storage when window.localStorage is null", () => {
+      Object.defineProperty(window, "localStorage", {
+        value: null,
+        configurable: true,
+      });
+
+      // $FlowIssue mock
+      uniqueID.mockReturnValue("fake-id-null-storage");
+      const globalStore = {};
+      // $FlowIssue mock
+      getGlobal.mockReturnValue(globalStore);
+
+      const { getID } = getStorage({ name: "test-null-storage" });
+
+      expect(() => getID()).not.toThrow();
+      expect(getID()).toEqual("fake-id-null-storage");
+      expect(globalStore["__test-null-storage_storage__"]).toBeTruthy();
+    });
+
+    test("falls back to global storage when localStorage.getItem throws", () => {
+      // $FlowIssue mock
+      uniqueID.mockReturnValue("fake-id-getitem-throw");
+      const globalStore = {};
+      // $FlowIssue mock
+      getGlobal.mockReturnValue(globalStore);
+      Object.defineProperty(window, "localStorage", {
+        value: {
+          getItem: () => {
+            throw new Error("SecurityError: localStorage access denied");
+          },
+          setItem: () => {},
+        },
+        configurable: true,
+      });
+
+      const { getID } = getStorage({ name: "test-getitem-throw" });
+
+      expect(() => getID()).not.toThrow();
+      expect(getID()).toEqual("fake-id-getitem-throw");
+    });
+
+    test("falls back to global storage when localStorage.setItem throws", () => {
+      // $FlowIssue mock
+      uniqueID.mockReturnValue("fake-id-setitem-throw");
+      const globalStore = {};
+      // $FlowIssue mock
+      getGlobal.mockReturnValue(globalStore);
+      Object.defineProperty(window, "localStorage", {
+        value: {
+          getItem: () => null,
+          setItem: () => {
+            throw new Error("SecurityError: localStorage access denied");
+          },
+        },
+        configurable: true,
+      });
+
+      const { getID } = getStorage({ name: "test-setitem-throw" });
+
+      expect(() => getID()).not.toThrow();
+      expect(getID()).toEqual("fake-id-setitem-throw");
+      expect(globalStore["__test-setitem-throw_storage__"]).toBeTruthy();
+    });
+
+    test("does not throw when isLocalStorageEnabled itself throws", () => {
+      // $FlowIssue mock
+      uniqueID.mockReturnValue("fake-id-enabled-throw");
+      const globalStore = {};
+      // $FlowIssue mock
+      getGlobal.mockReturnValue(globalStore);
+      // $FlowIssue mock
+      isLocalStorageEnabled.mockImplementationOnce(() => {
+        throw new Error("SecurityError: The operation is insecure");
+      });
+
+      const { getID } = getStorage({ name: "test-enabled-throw" });
+
+      expect(() => getID()).not.toThrow();
+      expect(getID()).toEqual("fake-id-enabled-throw");
+    });
   });
 });

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -133,6 +133,54 @@ describe("storage", () => {
       expect(globalStore["__test-setitem-throw_storage__"]).toBeTruthy();
     });
 
+    test("does not let a stale localStorage read clobber newer fallback data once localStorage recovers", () => {
+      // $FlowIssue mock
+      uniqueID.mockReturnValue("fake-id-fallback-newer");
+      const globalStore = {};
+      // $FlowIssue mock
+      getGlobal.mockReturnValue(globalStore);
+
+      let store: string | null = null;
+      let shouldFail = false;
+
+      Object.defineProperty(window, "localStorage", {
+        value: {
+          getItem: () => store,
+          setItem: (key, value) => {
+            if (shouldFail) {
+              throw new Error("SecurityError: localStorage access denied");
+            }
+
+            store = value;
+          },
+        },
+        configurable: true,
+      });
+
+      const { getSessionState } = getStorage({ name: "test-fallback-newer" });
+
+      // establish a baseline successful write to localStorage
+      getSessionState((state) => {
+        state.remembered = false;
+      });
+
+      // localStorage fails transiently while writing newer data; the write
+      // is redirected to the getGlobal() fallback instead
+      shouldFail = true;
+      getSessionState((state) => {
+        state.remembered = true;
+      });
+
+      // localStorage recovers, but its on-disk value is still the stale one
+      // written before the transient failure
+      shouldFail = false;
+      const remembered = getSessionState((state) => state.remembered);
+
+      expect(remembered).toBe(true);
+      expect(store).not.toBeNull();
+      expect(JSON.parse(store || "").__session__.state.remembered).toBe(true);
+    });
+
     test("does not throw when isLocalStorageEnabled itself throws", () => {
       // $FlowIssue mock
       uniqueID.mockReturnValue("fake-id-enabled-throw");


### PR DESCRIPTION
Adds a check for `window.localStorage` before `isLocalStorageEnabled`. Also wraps `getItem` and `setItem` calls in `try/catch`, falling back to global storage instead of throwing.